### PR TITLE
[Task 4] Implement Group repository layer

### DIFF
--- a/api/repositories/GroupRepository.ts
+++ b/api/repositories/GroupRepository.ts
@@ -26,7 +26,14 @@ interface GroupRow {
 }
 
 export class SQLiteGroupRepository implements GroupRepository {
-  private db = getDatabase();
+  private _db: ReturnType<typeof getDatabase> | null = null;
+
+  private get db() {
+    if (!this._db) {
+      this._db = getDatabase();
+    }
+    return this._db;
+  }
 
   private mapRowToGroup(row: GroupRow): Group {
     return {
@@ -103,7 +110,7 @@ export class SQLiteGroupRepository implements GroupRepository {
 
     // Build dynamic update query
     const updateFields: string[] = [];
-    const values: any[] = [];
+    const values: (string | null)[] = [];
 
     if (updates.name !== undefined) {
       updateFields.push('name = ?');

--- a/api/repositories/GroupRepository.ts
+++ b/api/repositories/GroupRepository.ts
@@ -1,9 +1,12 @@
 /**
- * Group repository interface
+ * Group repository interface and implementation
  * Defines data access operations for Group entities
  */
 
+import { randomUUID } from 'crypto';
 import type { Group, CreateGroupDto, UpdateGroupDto } from '../models/Group';
+import { getDatabase } from '../database/connection';
+import { DatabaseError, NotFoundError, ConflictError, handleDatabaseError } from '../utils/errors';
 
 export interface GroupRepository {
   create(group: CreateGroupDto): Promise<Group>;
@@ -14,29 +17,172 @@ export interface GroupRepository {
   findByName(name: string): Promise<Group | null>;
 }
 
-// Placeholder implementation - will be implemented in task 4
+interface GroupRow {
+  id: string;
+  name: string;
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 export class SQLiteGroupRepository implements GroupRepository {
+  private db = getDatabase();
+
+  private mapRowToGroup(row: GroupRow): Group {
+    return {
+      id: row.id,
+      name: row.name,
+      description: row.description || undefined,
+      createdAt: new Date(row.created_at),
+      updatedAt: new Date(row.updated_at),
+    };
+  }
+
   async create(group: CreateGroupDto): Promise<Group> {
-    throw new Error('Not implemented');
+    const id = randomUUID();
+    const now = new Date().toISOString();
+
+    try {
+      const stmt = this.db.prepare(`
+        INSERT INTO groups (id, name, description, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+      `);
+
+      stmt.run(id, group.name, group.description || null, now, now);
+
+      const createdGroup = await this.findById(id);
+      if (!createdGroup) {
+        throw new DatabaseError('Failed to create group');
+      }
+
+      return createdGroup;
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('UNIQUE constraint failed')) {
+        throw new ConflictError(`Group with name '${group.name}' already exists`);
+      }
+      throw handleDatabaseError(error as Error);
+    }
   }
 
   async findById(id: string): Promise<Group | null> {
-    throw new Error('Not implemented');
+    try {
+      const stmt = this.db.prepare(`
+        SELECT id, name, description, created_at, updated_at
+        FROM groups
+        WHERE id = ?
+      `);
+
+      const row = stmt.get(id) as GroupRow | undefined;
+      return row ? this.mapRowToGroup(row) : null;
+    } catch (error) {
+      throw handleDatabaseError(error as Error);
+    }
   }
 
   async findAll(): Promise<Group[]> {
-    throw new Error('Not implemented');
+    try {
+      const stmt = this.db.prepare(`
+        SELECT id, name, description, created_at, updated_at
+        FROM groups
+        ORDER BY name ASC
+      `);
+
+      const rows = stmt.all() as GroupRow[];
+      return rows.map(row => this.mapRowToGroup(row));
+    } catch (error) {
+      throw handleDatabaseError(error as Error);
+    }
   }
 
   async update(id: string, updates: UpdateGroupDto): Promise<Group> {
-    throw new Error('Not implemented');
+    // First check if the group exists
+    const existingGroup = await this.findById(id);
+    if (!existingGroup) {
+      throw new NotFoundError('Group', id);
+    }
+
+    // Build dynamic update query
+    const updateFields: string[] = [];
+    const values: any[] = [];
+
+    if (updates.name !== undefined) {
+      updateFields.push('name = ?');
+      values.push(updates.name);
+    }
+
+    if (updates.description !== undefined) {
+      updateFields.push('description = ?');
+      values.push(updates.description);
+    }
+
+    if (updateFields.length === 0) {
+      // No updates provided, return existing group
+      return existingGroup;
+    }
+
+    updateFields.push('updated_at = ?');
+    values.push(new Date().toISOString());
+    values.push(id);
+
+    try {
+      const stmt = this.db.prepare(`
+        UPDATE groups
+        SET ${updateFields.join(', ')}
+        WHERE id = ?
+      `);
+
+      const result = stmt.run(...values);
+      
+      if (result.changes === 0) {
+        throw new NotFoundError('Group', id);
+      }
+
+      const updatedGroup = await this.findById(id);
+      if (!updatedGroup) {
+        throw new DatabaseError('Failed to retrieve updated group');
+      }
+
+      return updatedGroup;
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        throw error;
+      }
+      if (error instanceof Error && error.message.includes('UNIQUE constraint failed')) {
+        throw new ConflictError(`Group with name '${updates.name}' already exists`);
+      }
+      throw handleDatabaseError(error as Error);
+    }
   }
 
   async delete(id: string): Promise<boolean> {
-    throw new Error('Not implemented');
+    try {
+      const stmt = this.db.prepare(`
+        DELETE FROM groups
+        WHERE id = ?
+      `);
+
+      const result = stmt.run(id);
+      return result.changes > 0;
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('FOREIGN KEY constraint failed')) {
+        throw new ConflictError('Cannot delete group that has associated network services');
+      }
+      throw handleDatabaseError(error as Error);
+    }
   }
 
   async findByName(name: string): Promise<Group | null> {
-    throw new Error('Not implemented');
+    try {
+      const stmt = this.db.prepare(`
+        SELECT id, name, description, created_at, updated_at
+        FROM groups
+        WHERE name = ?
+      `);
+
+      const row = stmt.get(name) as GroupRow | undefined;
+      return row ? this.mapRowToGroup(row) : null;
+    } catch (error) {
+      throw handleDatabaseError(error as Error);
+    }
   }
 }

--- a/tests/unit/repositories/GroupRepository.test.ts
+++ b/tests/unit/repositories/GroupRepository.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Unit tests for GroupRepository
+ */
+
+import { SQLiteGroupRepository } from '../../../api/repositories/GroupRepository';
+import { getDatabase, closeDatabase } from '../../../api/database/connection';
+import { DatabaseError, NotFoundError, ConflictError } from '../../../api/utils/errors';
+import type { CreateGroupDto, UpdateGroupDto } from '../../../api/models/Group';
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import path from 'path';
+
+describe('GroupRepository', () => {
+  let repository: SQLiteGroupRepository;
+  let testDbPath: string;
+
+  beforeAll(() => {
+    // Create a test database path
+    testDbPath = path.join(__dirname, '../../fixtures/test-groups.db');
+    
+    // Ensure test directory exists
+    const testDir = path.dirname(testDbPath);
+    if (!fs.existsSync(testDir)) {
+      fs.mkdirSync(testDir, { recursive: true });
+    }
+
+    // Set test database path
+    process.env.DATABASE_PATH = testDbPath;
+  });
+
+  beforeEach(async () => {
+    // Clean up any existing database
+    if (fs.existsSync(testDbPath)) {
+      fs.unlinkSync(testDbPath);
+    }
+
+    // Initialize database with schema
+    const db = getDatabase();
+    
+    // Create groups table
+    db.exec(`
+      CREATE TABLE groups (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE,
+        description TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      );
+
+      CREATE TRIGGER update_groups_updated_at
+        AFTER UPDATE ON groups
+        FOR EACH ROW
+      BEGIN
+        UPDATE groups SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
+      END;
+    `);
+
+    repository = new SQLiteGroupRepository();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  afterAll(() => {
+    // Clean up test database
+    if (fs.existsSync(testDbPath)) {
+      fs.unlinkSync(testDbPath);
+    }
+  });
+
+  describe('create', () => {
+    it('should create a new group successfully', async () => {
+      const groupData: CreateGroupDto = {
+        name: 'Test Group',
+        description: 'A test group'
+      };
+
+      const result = await repository.create(groupData);
+
+      expect(result).toMatchObject({
+        name: 'Test Group',
+        description: 'A test group'
+      });
+      expect(result.id).toBeDefined();
+      expect(result.createdAt).toBeInstanceOf(Date);
+      expect(result.updatedAt).toBeInstanceOf(Date);
+    });
+
+    it('should create a group without description', async () => {
+      const groupData: CreateGroupDto = {
+        name: 'Test Group'
+      };
+
+      const result = await repository.create(groupData);
+
+      expect(result.name).toBe('Test Group');
+      expect(result.description).toBeUndefined();
+      expect(result.id).toBeDefined();
+    });
+
+    it('should throw ConflictError for duplicate group names', async () => {
+      const groupData: CreateGroupDto = {
+        name: 'Duplicate Group'
+      };
+
+      await repository.create(groupData);
+
+      await expect(repository.create(groupData))
+        .rejects
+        .toThrow(ConflictError);
+    });
+
+    it('should handle database errors gracefully', async () => {
+      // Close database to simulate error
+      closeDatabase();
+
+      const groupData: CreateGroupDto = {
+        name: 'Test Group'
+      };
+
+      await expect(repository.create(groupData))
+        .rejects
+        .toThrow(DatabaseError);
+    });
+  });
+
+  describe('findById', () => {
+    it('should find an existing group by id', async () => {
+      const groupData: CreateGroupDto = {
+        name: 'Test Group',
+        description: 'A test group'
+      };
+
+      const created = await repository.create(groupData);
+      const found = await repository.findById(created.id);
+
+      expect(found).toMatchObject({
+        id: created.id,
+        name: 'Test Group',
+        description: 'A test group'
+      });
+    });
+
+    it('should return null for non-existent group', async () => {
+      const result = await repository.findById('non-existent-id');
+      expect(result).toBeNull();
+    });
+
+    it('should handle database errors gracefully', async () => {
+      closeDatabase();
+
+      await expect(repository.findById('some-id'))
+        .rejects
+        .toThrow(DatabaseError);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return empty array when no groups exist', async () => {
+      const result = await repository.findAll();
+      expect(result).toEqual([]);
+    });
+
+    it('should return all groups ordered by name', async () => {
+      await repository.create({ name: 'Zebra Group' });
+      await repository.create({ name: 'Alpha Group' });
+      await repository.create({ name: 'Beta Group' });
+
+      const result = await repository.findAll();
+
+      expect(result).toHaveLength(3);
+      expect(result[0].name).toBe('Alpha Group');
+      expect(result[1].name).toBe('Beta Group');
+      expect(result[2].name).toBe('Zebra Group');
+    });
+
+    it('should handle database errors gracefully', async () => {
+      closeDatabase();
+
+      await expect(repository.findAll())
+        .rejects
+        .toThrow(DatabaseError);
+    });
+  });
+
+  describe('update', () => {
+    it('should update group name successfully', async () => {
+      const created = await repository.create({ name: 'Original Name' });
+      const updates: UpdateGroupDto = { name: 'Updated Name' };
+
+      const result = await repository.update(created.id, updates);
+
+      expect(result.name).toBe('Updated Name');
+      expect(result.id).toBe(created.id);
+      expect(result.createdAt).toEqual(created.createdAt);
+      // The updated_at should be set to a recent timestamp
+      expect(result.updatedAt).toBeInstanceOf(Date);
+    });
+
+    it('should update group description successfully', async () => {
+      const created = await repository.create({ name: 'Test Group' });
+      const updates: UpdateGroupDto = { description: 'New description' };
+
+      const result = await repository.update(created.id, updates);
+
+      expect(result.description).toBe('New description');
+      expect(result.name).toBe('Test Group');
+    });
+
+    it('should update both name and description', async () => {
+      const created = await repository.create({ name: 'Test Group' });
+      const updates: UpdateGroupDto = {
+        name: 'Updated Name',
+        description: 'Updated description'
+      };
+
+      const result = await repository.update(created.id, updates);
+
+      expect(result.name).toBe('Updated Name');
+      expect(result.description).toBe('Updated description');
+    });
+
+    it('should return existing group when no updates provided', async () => {
+      const created = await repository.create({ name: 'Test Group' });
+      const updates: UpdateGroupDto = {};
+
+      const result = await repository.update(created.id, updates);
+
+      expect(result).toEqual(created);
+    });
+
+    it('should throw NotFoundError for non-existent group', async () => {
+      const updates: UpdateGroupDto = { name: 'Updated Name' };
+
+      await expect(repository.update('non-existent-id', updates))
+        .rejects
+        .toThrow(NotFoundError);
+    });
+
+    it('should throw ConflictError for duplicate name', async () => {
+      await repository.create({ name: 'Existing Group' });
+      const created = await repository.create({ name: 'Test Group' });
+      
+      const updates: UpdateGroupDto = { name: 'Existing Group' };
+
+      await expect(repository.update(created.id, updates))
+        .rejects
+        .toThrow(ConflictError);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete an existing group successfully', async () => {
+      const created = await repository.create({ name: 'Test Group' });
+
+      const result = await repository.delete(created.id);
+
+      expect(result).toBe(true);
+
+      // Verify group is deleted
+      const found = await repository.findById(created.id);
+      expect(found).toBeNull();
+    });
+
+    it('should return false for non-existent group', async () => {
+      const result = await repository.delete('non-existent-id');
+      expect(result).toBe(false);
+    });
+
+    it('should throw ConflictError when group has foreign key constraints', async () => {
+      // First create the network_services table to test foreign key constraint
+      const db = getDatabase();
+      db.exec(`
+        CREATE TABLE network_services (
+          id TEXT PRIMARY KEY,
+          group_id TEXT NOT NULL,
+          name TEXT NOT NULL,
+          domain TEXT NOT NULL,
+          FOREIGN KEY (group_id) REFERENCES groups(id) ON DELETE CASCADE
+        );
+      `);
+
+      const created = await repository.create({ name: 'Test Group' });
+      
+      // Insert a network service that references this group
+      db.prepare(`
+        INSERT INTO network_services (id, group_id, name, domain)
+        VALUES (?, ?, ?, ?)
+      `).run('service-1', created.id, 'Test Service', 'test.com');
+
+      // Disable foreign key constraints to simulate the error condition
+      db.pragma('foreign_keys = OFF');
+      db.exec(`
+        CREATE TRIGGER prevent_group_delete
+        BEFORE DELETE ON groups
+        FOR EACH ROW
+        WHEN EXISTS (SELECT 1 FROM network_services WHERE group_id = OLD.id)
+        BEGIN
+          SELECT RAISE(ABORT, 'FOREIGN KEY constraint failed');
+        END;
+      `);
+
+      await expect(repository.delete(created.id))
+        .rejects
+        .toThrow(ConflictError);
+    });
+  });
+
+  describe('findByName', () => {
+    it('should find an existing group by name', async () => {
+      const created = await repository.create({
+        name: 'Test Group',
+        description: 'A test group'
+      });
+
+      const found = await repository.findByName('Test Group');
+
+      expect(found).toMatchObject({
+        id: created.id,
+        name: 'Test Group',
+        description: 'A test group'
+      });
+    });
+
+    it('should return null for non-existent group name', async () => {
+      const result = await repository.findByName('Non-existent Group');
+      expect(result).toBeNull();
+    });
+
+    it('should be case sensitive', async () => {
+      await repository.create({ name: 'Test Group' });
+
+      const result = await repository.findByName('test group');
+      expect(result).toBeNull();
+    });
+
+    it('should handle database errors gracefully', async () => {
+      closeDatabase();
+
+      await expect(repository.findByName('Test Group'))
+        .rejects
+        .toThrow(DatabaseError);
+    });
+  });
+});

--- a/tests/unit/repositories/GroupRepository.test.ts
+++ b/tests/unit/repositories/GroupRepository.test.ts
@@ -112,16 +112,24 @@ describe('GroupRepository', () => {
     });
 
     it('should handle database errors gracefully', async () => {
-      // Close database to simulate error
+      // Create a repository with an invalid database path to simulate error
+      const originalPath = process.env.DATABASE_PATH;
+      process.env.DATABASE_PATH = '/invalid/path/that/does/not/exist.db';
+      
+      // Close existing database connection
       closeDatabase();
-
+      
+      const newRepository = new SQLiteGroupRepository();
       const groupData: CreateGroupDto = {
         name: 'Test Group'
       };
 
-      await expect(repository.create(groupData))
+      await expect(newRepository.create(groupData))
         .rejects
         .toThrow(DatabaseError);
+        
+      // Restore original path
+      process.env.DATABASE_PATH = originalPath;
     });
   });
 
@@ -148,11 +156,21 @@ describe('GroupRepository', () => {
     });
 
     it('should handle database errors gracefully', async () => {
+      // Create a repository with an invalid database path to simulate error
+      const originalPath = process.env.DATABASE_PATH;
+      process.env.DATABASE_PATH = '/invalid/path/that/does/not/exist.db';
+      
+      // Close existing database connection
       closeDatabase();
+      
+      const newRepository = new SQLiteGroupRepository();
 
-      await expect(repository.findById('some-id'))
+      await expect(newRepository.findById('some-id'))
         .rejects
         .toThrow(DatabaseError);
+        
+      // Restore original path
+      process.env.DATABASE_PATH = originalPath;
     });
   });
 
@@ -176,11 +194,21 @@ describe('GroupRepository', () => {
     });
 
     it('should handle database errors gracefully', async () => {
+      // Create a repository with an invalid database path to simulate error
+      const originalPath = process.env.DATABASE_PATH;
+      process.env.DATABASE_PATH = '/invalid/path/that/does/not/exist.db';
+      
+      // Close existing database connection
       closeDatabase();
+      
+      const newRepository = new SQLiteGroupRepository();
 
-      await expect(repository.findAll())
+      await expect(newRepository.findAll())
         .rejects
         .toThrow(DatabaseError);
+        
+      // Restore original path
+      process.env.DATABASE_PATH = originalPath;
     });
   });
 
@@ -336,11 +364,21 @@ describe('GroupRepository', () => {
     });
 
     it('should handle database errors gracefully', async () => {
+      // Create a repository with an invalid database path to simulate error
+      const originalPath = process.env.DATABASE_PATH;
+      process.env.DATABASE_PATH = '/invalid/path/that/does/not/exist.db';
+      
+      // Close existing database connection
       closeDatabase();
+      
+      const newRepository = new SQLiteGroupRepository();
 
-      await expect(repository.findByName('Test Group'))
+      await expect(newRepository.findByName('Test Group'))
         .rejects
         .toThrow(DatabaseError);
+        
+      // Restore original path
+      process.env.DATABASE_PATH = originalPath;
     });
   });
 });


### PR DESCRIPTION
Implements task 4 from the Network Source of Truth specification.

## Changes Made
- Implemented complete SQLiteGroupRepository class with all CRUD operations
- Added proper error handling for database constraints and foreign key violations  
- Created comprehensive unit test suite with 23 test cases covering all methods
- Added UUID generation for unique group IDs
- Implemented dynamic update queries and row mapping

## CRUD Operations Implemented
- create(): Creates new groups with validation and conflict detection
- findById(): Retrieves groups by ID with null handling
- findAll(): Returns all groups ordered by name
- update(): Updates groups with dynamic field updates and conflict detection
- delete(): Deletes groups with foreign key constraint handling
- findByName(): Additional method for finding groups by name

## Error Handling
- ConflictError for duplicate group names
- NotFoundError for non-existent groups  
- ConflictError for foreign key violations when deleting groups with services
- DatabaseError for general database operation failures

## Testing
- 23 comprehensive unit tests covering all methods and error scenarios
- All tests passing successfully
- Test database setup and teardown properly implemented

## Requirements Satisfied
- Requirement 1.1: Store and manage network service information
- Requirement 1.3: Update network service records
- Requirement 1.4: Delete network service records

Ready for review and merge.