### PR TITLE
chore(security): override transitive postcss to ^8.5.16 (Dependabot #34)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10049,34 +10049,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-abi": {
       "version": "3.94.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",

--- a/package.json
+++ b/package.json
@@ -80,5 +80,8 @@
     "ts-node": "^10.9.2",
     "tw-animate-css": "^1.3.6",
     "typescript": "^6"
+  },
+  "overrides": {
+    "postcss": "^8.5.16"
   }
 }


### PR DESCRIPTION
## Summary
Resolves Dependabot alert **#34** (postcss XSS via unescaped `</style>` in CSS stringify output, medium).

`next@16.2.10` pins `postcss@8.4.31` transitively — below the `8.5.10` patch — so it can't dedupe to the top-level `postcss@8.5.16` and the alert stays open. This forces the patched line across the whole tree via npm `overrides`.

## Verification
- `npm audit`: **0 vulnerabilities**
- No `postcss < 8.5.10` remaining in the tree
- `npm run build`: green (compiles + 11/11 pages prerender)

## Note
This is a follow-up to #29 — the override commit was pushed just after #29 was squash-merged, so it never made it onto `main`. This PR lands it cleanly on top of current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)