### PR TITLE
chore(deps): ignore typescript, eslint majors until ecosystem supports them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,10 @@ updates:
     groups:
       minor-and-patch:
         update-types: ["minor", "patch"]
+    # TS7 blocked by typescript-eslint/ts-jest peer range (typescript <6.1.0);
+    # ESLint 10 breaks eslint-plugin-react. Lift when ecosystem supports it (2026-07-18)
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Closes #36

typescript-eslint/ts-jest pin typescript <6.1.0; ESLint 10 breaks eslint-plugin-react. Verified breaking on 2026-07-18. Ignore majors until the ecosystem catches up.